### PR TITLE
Fixes ruin generation

### DIFF
--- a/code/modules/mapping/map_template.dm
+++ b/code/modules/mapping/map_template.dm
@@ -11,7 +11,7 @@
 	if(path)
 		mappath = path
 	if(mappath)
-		INVOKE_ASYNC(src, .proc/preload_size, mappath, cache)
+		preload_size(mappath, cache)
 	if(rename)
 		name = rename
 


### PR DESCRIPTION
## About The Pull Request

Changes the bounds size proc from async to not. We need to make sure the bounds on map templates are correct before they are spawned or weird issues can happen. Fixes #53542

## Why It's Good For The Game

Ruins spawning on station bad.

## Changelog
:cl: Joe Berry
fix: Seperates the frost miner cabin from the station and places it in the ice moon wastes.
/:cl: